### PR TITLE
fix test-only buffer overwrite

### DIFF
--- a/aegis_arm64.s
+++ b/aegis_arm64.s
@@ -39,9 +39,15 @@
 
 // func copy32(dst, src []byte)
 TEXT ·copy32(SB), NOSPLIT, $0-48
-	MOVD dst_base+0(FP), R8
-	MOVD src_base+24(FP), R1
-	MOVD src_len+32(FP), R3
+	MOVD  dst_base+0(FP), R8
+	MOVD  dst_len+8(FP), R9
+	MOVD  src_base+24(FP), R1
+	MOVD  src_len+32(FP), R3
+	CMP   R3, R9              // Is len(dst) < len(src)?
+	BGE   do_copy             // Nope
+	MOVWU R9, R3              // Yep, set len(src) = len(dst)
+
+do_copy:
 	CALL copy32<>(SB)
 	RET
 


### PR DESCRIPTION
`·copy32` (the function exposed to Go) was writing past the end of the dst, causing `go test` to segfault. Interestingly, this did not occur when other flags were used, like `go test -v`. I guess this rearranged things in memory just right.

This is not a security bug as the seal/open routines always reserve 32 bytes of stack space for the write, equivalent to invoking `·copy32(make([]byte, 32), ...)`.

Thanks @jedisct1

Fixes #14